### PR TITLE
fix(pkg): Remove node_modules from .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,4 +9,3 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
-node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "add-gitlab-npm-token",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2999,9 +2999,9 @@
 			}
 		},
 		"typescript": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
 			"dev": true
 		},
 		"uc.micro": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "vymarkov",
 	"displayName": "GitLab: Configure access to GitLab NPM Registry",
 	"description": "It allows to configure access to GitLab NPM Registry from your workstation whenever you are working on repo where npm dependencies could be fetched from Gitlab NPM registry only",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"license": "MIT",
 	"repository": {
 		"type": "git",
@@ -44,7 +44,9 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compile": "tsc -p ./",
+		"precompile": "npm run lint",
+		"compile": "npx tsc -p ./",
+		"pkg": "npx vsce package",
 		"lint": "eslint src --ext ts",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",
@@ -63,7 +65,7 @@
 		"mocha": "^8.1.3",
 		"ovsx": "0.1.0-next.72b2e9d",
 		"ts-node": "^9.1.1",
-		"typescript": "^4.1.3",
+		"typescript": "^4.0.5",
 		"vsce": "^1.83.0",
 		"vscode-test": "^1.4.0"
 	},


### PR DESCRIPTION
vsce cli doesn't include package-lock.json into ext archive, it's tmp fix